### PR TITLE
Extract linter_name from payload

### DIFF
--- a/lib/linter.js
+++ b/lib/linter.js
@@ -20,6 +20,7 @@ Linter.prototype.lint = function(payload) {
     return this.houndJavascript.completeFileReview({
       violations: violations,
       filename: payload.filename,
+      linter_name: payload.linter_name,
       commit_sha: payload.commit_sha,
       pull_request_number: payload.pull_request_number,
       patch: payload.patch,
@@ -28,7 +29,7 @@ Linter.prototype.lint = function(payload) {
     return this.houndJavascript.reportInvalidConfig({
       pull_request_number: payload.pull_request_number,
       commit_sha: payload.commit_sha,
-      linter_name: "jshint",
+      linter_name: payload.linter_name,
     });
   }
 };

--- a/tests/linter-test.js
+++ b/tests/linter-test.js
@@ -16,6 +16,7 @@ asyncTest("JSHint linting", function() {
     config: "{ \"undef\": true }",
     filename: "filename",
     commit_sha: "commit_sha",
+    linter_name: "hound_assigned_name",
     pull_request_number: "pull_request_number",
     patch: "patch",
   };
@@ -38,6 +39,7 @@ asyncTest("JSHint linting", function() {
           violations: [ { line: 1, message: "'foo' is not defined." } ],
           filename: "filename",
           commit_sha: "commit_sha",
+          linter_name: "hound_assigned_name",
           pull_request_number: "pull_request_number",
           patch: "patch",
         },
@@ -52,6 +54,7 @@ asyncTest("Reporting an invalid configuration file", function() {
     content: "// TODO",
     config: "---\nyaml: is good\ntrue/false/syntax/error",
     filename: "filename",
+    linter_name: "hound_assigned_name",
     commit_sha: "commit_sha",
     pull_request_number: "pull_request_number",
     patch: "patch",
@@ -74,7 +77,7 @@ asyncTest("Reporting an invalid configuration file", function() {
         {
           commit_sha: "commit_sha",
           pull_request_number: "pull_request_number",
-          linter_name: "jshint",
+          linter_name: "hound_assigned_name",
         },
         "pushes a job onto the queue"
       );


### PR DESCRIPTION
[Related Hound pull](https://github.com/houndci/hound/pull/1102)

It is possible for Hound to assign more than one linter to review a single file
in a build. Because of this, when Hound dequeues an incoming
CompletedFileReview, it needs to know both the name of the file linted and the
linter reporting any errors.

This change updates the JShint linter to look for a linter_name key in the
payload object dequeued from Redis. It then passes the linter name back either
upon successful completion of a review or when it detects a configuration error.